### PR TITLE
Added error handling for failed API calls

### DIFF
--- a/enable-checkpoint.py
+++ b/enable-checkpoint.py
@@ -1,6 +1,7 @@
 import sys
 import probes
 import checkpointservers
+from requests import exceptions
 
 user = sys.argv[1]
 secret = sys.argv[2]
@@ -18,9 +19,18 @@ if probeId == "all":
 else:
     probe_list.append(probes.getProbe(probeId, user, secret))
 
+update_failures = []
 for probe in probe_list:
     print("Adding checkpoint " + str(checkpoint["Id"])
           + " to probe " + probe["Name"])
-    probes.addCheckpoint(checkpoint["Id"], probe, user, secret)
+    try:
+        probes.addCheckpoint(checkpoint["Id"], probe, user, secret)
+    except exceptions.HTTPError as err:
+        print("Failed to remove checkpoint from probe " + probe["Name"] + " - " + str(err))
+        update_failures.append(probe)
 
 print("Complete")
+if len(update_failures) > 0:
+    print("\nNOTE: Failed to add checkpoint to following probe(s).  Please update manually.")
+    for probe in update_failures:
+        print(probe["Name"])


### PR DESCRIPTION
Sometimes calls will fail for certain types of monitors.  When this happens, the current revision of these scripts will stop.  I added a try/except clause around the call to the Uptrends API.  If a call fails, it's added to a list and displayed to the user at the end of the run so that they can go in and update the monitors by hand.  At some point, we should figure out why these calls return a 400, but that's a problem for a later day.